### PR TITLE
fix: run each Lua test wrapper argument

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -48,8 +48,8 @@ Build and smoke test
    test bitwise.lua calls.lua
    ```
 
-   The wrapper expands those names against `..\lua\testes\` and invokes the
-   built `script` executable for each file.
+   The wrapper requires at least one test name, expands each name against
+   `..\lua\testes\`, and invokes the built `script` executable for each file.
 
 Notes
 -----

--- a/win_lua/test.cmd
+++ b/win_lua/test.cmd
@@ -1,1 +1,8 @@
-for %%G in (../lua/testes/%*) do script %%G
+@echo off
+if "%~1"=="" (
+    echo Usage: test ^<lua-test-name^> [more-test-names...]
+    echo Example: test bitwise.lua calls.lua
+    exit /b 1
+)
+
+for %%G in (%*) do script "..\lua\testes\%%~G"


### PR DESCRIPTION
## Summary
- Update `win_lua/test.cmd` to require at least one test name and print usage when none are supplied.
- Iterate over each requested Lua test name before prefixing it with `..\lua\testes\`, so `test bitwise.lua calls.lua` runs both files from the upstream test directory.
- Clarify the wrapper behavior in `readme.txt`.

## Verification
- Static check confirmed `win_lua/test.cmd` contains the usage guard, the per-argument `..\lua\testes\%%~G` expansion, and no stale `../lua/testes/%*` pattern.
- Static check confirmed `readme.txt` documents the one-or-more test-name requirement and upstream test-directory expansion.
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD~1..HEAD`

## Notes
- Visual Studio build/runtime execution was not run for this batch-wrapper-only change.
