### PR TITLE
fix: preserve script smoke test cwd

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -54,9 +54,11 @@ Build and smoke test
 Notes
 -----
 
-- `script.c` changes the working directory to the upstream `lua/testes`
-  directory before executing arguments. This keeps the upstream tests close to
-  their expected runtime layout.
+- `script.c` keeps plain script names relative to the current output directory, so
+  `script script.lua` works as a quick smoke test. When a script argument
+  includes a directory, the launcher changes to that directory before executing
+  the file basename; this keeps upstream Lua tests close to their expected
+  runtime layout.
 - The Lua test suite was originally designed for non-Windows environments, so
   some tests are expected to be partial or configuration-dependent; see
   `win_lua/test_results.txt` for the existing result notes.

--- a/win_lua/script.c
+++ b/win_lua/script.c
@@ -1,19 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define change_dir _chdir
+#else
+#include <unistd.h>
+#define change_dir chdir
+#endif
+
 #include "lauxlib.h"
 #include "lua.h"
 #include "lualib.h"
 
-int main(int argc, char* argv[]) {
-	chdir("../../../../lua/testes");
-	lua_State* L = luaL_newstate();
-	luaL_openlibs(L);
+static char* last_path_separator(char* path) {
+	char* slash = strrchr(path, '/');
+	char* backslash = strrchr(path, '\\');
 
-	printf("argc = %d\n", argc);
-	for (int ndx = 0; ndx != argc; ++ndx) {
-		printf("argv[%d] --> %s\n", ndx, argv[ndx]);
-		if (ndx > 0) {
-			luaL_dofile(L, argv[ndx]);
+	if (slash == NULL) return backslash;
+	if (backslash == NULL) return slash;
+	return slash > backslash ? slash : backslash;
+}
+
+static int dofile_from_argument(lua_State* L, const char* argument) {
+	char path[FILENAME_MAX];
+	snprintf(path, sizeof(path), "%s", argument);
+
+	char* file = path;
+	char* separator = last_path_separator(path);
+	if (separator != NULL) {
+		*separator = '\0';
+		file = separator + 1;
+		if (change_dir(path) != 0) {
+			fprintf(stderr, "could not enter test directory: %s\n", path);
+			return 1;
 		}
 	}
 
+	if (luaL_dofile(L, file) != LUA_OK) {
+		fprintf(stderr, "%s\n", lua_tostring(L, -1));
+		lua_pop(L, 1);
+		return 1;
+	}
+
 	return 0;
+}
+
+int main(int argc, char* argv[]) {
+	lua_State* L = luaL_newstate();
+	if (L == NULL) {
+		fprintf(stderr, "failed to create Lua state\n");
+		return 1;
+	}
+	luaL_openlibs(L);
+
+	printf("argc = %d\n", argc);
+	int result = 0;
+	for (int ndx = 0; ndx != argc; ++ndx) {
+		printf("argv[%d] --> %s\n", ndx, argv[ndx]);
+		if (ndx > 0 && dofile_from_argument(L, argv[ndx]) != 0) {
+			result = 1;
+			break;
+		}
+	}
+
+	lua_close(L);
+	return result;
 }


### PR DESCRIPTION
Summary:
- Keep plain script names relative to the current output directory so `script script.lua` continues to work after the Visual Studio post-build copy.
- When a test path includes a directory, enter that directory and execute the basename so upstream Lua tests can still run from their expected layout.
- Return a non-zero process status when Lua state creation or `luaL_dofile` fails.

Verification:
- Compiled `win_lua/script.c` with stub Lua headers/functions using `gcc -std=c17 -Wall -Wextra -Werror`.
- Exercised a plain `script.lua` argument, a path-qualified `lua/testes/bitwise.lua` argument, and a failing Lua file case.
- `git diff --check HEAD~1..HEAD`

Notes:
- Related: #6 updates `test.cmd` test-name expansion; this change is limited to the C launcher working-directory and error-handling behavior.
- Full Visual Studio build/runtime validation was not run here.